### PR TITLE
Fix execution with newer bazel version 3.4.0

### DIFF
--- a/bzl/autotest.bzl
+++ b/bzl/autotest.bzl
@@ -1,3 +1,13 @@
+load("@bazel_tools//tools/build_defs/repo:jvm.bzl", "jvm_maven_import_external")
+
+JUNIT_ARTIFACT = "junit:junit:4.10"
+
+MAVEN_SERVERS = [
+    "https://jcenter.bintray.com/",
+    "https://maven.google.com",
+    "https://repo1.maven.org/maven2",
+]
+
 def auto_java_test(name, srcs = [], deps = [], args = [], **kwargs):
   native.java_test(
       name = name,
@@ -12,9 +22,11 @@ def auto_java_test(name, srcs = [], deps = [], args = [], **kwargs):
 # JUnit jars used to run
 def autotest_junit_repo(junit_jar = "", autotest_workspace = ""):
   if junit_jar == "":
-    native.maven_jar(
-      name = "junit_artifact",
-      artifact = "junit:junit:4.10",
+    jvm_maven_import_external(
+        name = "junit_artifact",
+        artifact = JUNIT_ARTIFACT,
+        server_urls = MAVEN_SERVERS,
+        licenses = ["notice"],  # Apache 2.0
     )
     junit_jar = "@junit_artifact//jar"
   native.bind(name = "autotest_junit", actual = junit_jar)


### PR DESCRIPTION
The result now makes Bazel happy with versions >= 3.4.0. The underlying tests still fail on Java versions >= 9, this will be resolved in a future change.